### PR TITLE
Reference the proper location of the NPC the player has to speak to for the Slider puzzle

### DIFF
--- a/src/data/clues.ts
+++ b/src/data/clues.ts
@@ -3732,7 +3732,7 @@ export namespace clue_data {
       "challenge": [{"type": "slider"}],
       "solution": {
         "type": "talkto",
-        "spots": [{"range": {"origin": {"x": 2849, "y": 3492, "level": 1}, "size": {"x": 3, "y": 3}}, "description": "in eastern Karamja"}],
+        "spots": [{"range": {"origin": {"x": 2849, "y": 3492, "level": 1}, "size": {"x": 3, "y": 3}}, "description": "at the top of White Wolf Mountain"}],
         "npc": "Captain Bleemadge"
       }
     }, {


### PR DESCRIPTION
Captain Bleemadge is at the top of White Wolf Mountain. Captain Klemfoodle is the gnome in Eastern Karamja. The typical route to get to Bleemadge is through Klemfoodle w/ Overgrown GOTE tele but experienced cluers will already know this. Less experienced cluers may get confused that the NPC referenced isn't at the location that is referenced.

Overall an extremely minor issue - but it was something I noticed while doing hard clues. 